### PR TITLE
mali: kbase: fix kctx_list race in context init

### DIFF
--- a/drivers/misc/mediatek/gpu/gpu_mali/mali_bifrost/mali-r25p0/drivers/gpu/arm/midgard/context/backend/mali_kbase_context_jm.c
+++ b/drivers/misc/mediatek/gpu/gpu_mali/mali_bifrost/mali-r25p0/drivers/gpu/arm/midgard/context/backend/mali_kbase_context_jm.c
@@ -198,6 +198,18 @@ struct kbase_context *kbase_create_context(struct kbase_device *kbdev,
 		}
 	}
 
+	/* Make the context visible to kctx_list walkers (e.g. the
+	 * js_ctx_scheduling_mode sysfs handler) only now that every
+	 * context_init[] step - including kbasep_js_kctx_init - has
+	 * completed successfully. Adding it earlier (as common_init used
+	 * to) exposed a partially-initialised context whose JS list heads
+	 * were still zeroed, causing a NULL-pointer oops under the sysfs
+	 * scheduling-mode write path.
+	 */
+	mutex_lock(&kbdev->kctx_list_lock);
+	list_add(&kctx->kctx_list_link, &kbdev->kctx_list);
+	mutex_unlock(&kbdev->kctx_list_lock);
+
 	return kctx;
 }
 KBASE_EXPORT_SYMBOL(kbase_create_context);

--- a/drivers/misc/mediatek/gpu/gpu_mali/mali_bifrost/mali-r25p0/drivers/gpu/arm/midgard/context/mali_kbase_context.c
+++ b/drivers/misc/mediatek/gpu/gpu_mali/mali_bifrost/mali-r25p0/drivers/gpu/arm/midgard/context/mali_kbase_context.c
@@ -215,8 +215,12 @@ int kbase_context_common_init(struct kbase_context *kctx)
 
 	mutex_init(&kctx->legacy_hwcnt_lock);
 
+	/* Keep the list node valid (self-linked) even before it is added
+	 * to kbdev->kctx_list, so a later list_del_init() is always safe.
+	 */
+	INIT_LIST_HEAD(&kctx->kctx_list_link);
+
 	mutex_lock(&kctx->kbdev->kctx_list_lock);
-	list_add(&kctx->kctx_list_link, &kctx->kbdev->kctx_list);
 
 	err = kbase_insert_kctx_to_process(kctx);
 	if (err)
@@ -290,7 +294,7 @@ void kbase_context_common_term(struct kbase_context *kctx)
 	KBASE_TLSTREAM_TL_KBASE_DEL_CTX(kctx->kbdev, kctx->id);
 
 	KBASE_TLSTREAM_TL_DEL_CTX(kctx->kbdev, kctx);
-	list_del(&kctx->kctx_list_link);
+	list_del_init(&kctx->kctx_list_link);
 	mutex_unlock(&kctx->kbdev->kctx_list_lock);
 
 	KBASE_KTRACE_ADD(kctx->kbdev, CORE_CTX_DESTROY, kctx, 0u);


### PR DESCRIPTION
kbase_create_context() runs the context_init[] table in order:
  index 0: kbase_context_common_init   -> adds kctx to kbdev->kctx_list
  index 3: kbasep_js_kctx_init         -> initializes JS-specific
                                          per-context list heads

Between steps 0 and 3, the context is already visible on kctx_list (e.g. to the js_ctx_scheduling_mode sysfs handler) but its JS list heads are still zeroed (vzalloc'd, never INIT_LIST_HEAD'd). Any concurrent walker that dereferences those fields during this window hits a NULL pointer.

This matches recurring device panics with the signature:
  Unable to handle kernel NULL pointer dereference
  pc : kbase_js_set_ctx_priority+0xd4/0x1bc
  (and, on a later build: set_js_ctx_scheduling_mode+0x188/0x234)

Defer kctx_list_link's list_add to the end of kbase_create_context(), after every context_init[] step - including kbasep_js_kctx_init - has completed successfully. Use INIT_LIST_HEAD up front so the node is always safely self-linked even before it's added, and use list_del_init instead of list_del on teardown.